### PR TITLE
support specifying the field of a foreign key for mssql

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -52,7 +52,7 @@ module.exports = (function() {
     createSchema: function(schema){
       return SqlGenerator.getCreateSchemaSql(schema);
     },
-    showSchemasQuery: function(){   
+    showSchemasQuery: function(){
       return 'SELECT name FROM sys.Tables;';
     },
     /*
@@ -138,9 +138,10 @@ module.exports = (function() {
       var modelAttributeMap = {};
       if (modelAttributes) {
         Utils._.each(modelAttributes, function(attribute, key) {
-          modelAttributeMap[key] = attribute;
           if (attribute.field) {
             modelAttributeMap[attribute.field] = attribute;
+          } else {
+            modelAttributeMap[key] = attribute;
           }
         });
       }
@@ -161,13 +162,13 @@ module.exports = (function() {
 
       for(var key in attributes){
         var aliasKey = attributes[key].field || key;
-        if(ignoreKeys.indexOf(aliasKey) < 0){ 
+        if(ignoreKeys.indexOf(aliasKey) < 0){
           ignoreKeys.push(aliasKey);
         }
         if(attributes[key].autoIncrement){
           for(var i = 0; i < attrValueHashes.length; i++){
             if(aliasKey in attrValueHashes[i]){
-              delete attrValueHashes[i][aliasKey];            
+              delete attrValueHashes[i][aliasKey];
             }
           }
         }
@@ -203,7 +204,7 @@ module.exports = (function() {
           query += SqlGenerator.insertSql(tableName);
         }
       }
-      return query; 
+      return query;
     },
     /*
       Returns an update query.
@@ -229,7 +230,7 @@ module.exports = (function() {
             delete attrValueHash[aliasKey];
           }
           if(attrValueHash[aliasKey] && attrValueHash[aliasKey].fn){
-            
+
           }
         }
         if(!Object.keys(attrValueHash).length){
@@ -444,7 +445,7 @@ module.exports = (function() {
         }
 
         // add 1st string as quoted, 2nd as unquoted raw
-        var sql = (i > 0 ? SqlGenerator.quoteIdentifier(tableNames.join('.')) + '.' : '') 
+        var sql = (i > 0 ? SqlGenerator.quoteIdentifier(tableNames.join('.')) + '.' : '')
           + this.quote(obj[i], parent, force);
         if (i < len - 1) {
           sql += ' ' + obj[i + 1];


### PR DESCRIPTION
The MSSQL dialect implements its own sql generator, and was accidentally adding an extra raw attribute for an aliased field. Sorry for the whitespace changes, the editor has a mind of its own!
