### PR TITLE
fix addColumnQuery for ENUM types

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -52,7 +52,7 @@ module.exports = (function() {
     createSchema: function(schema){
       return SqlGenerator.getCreateSchemaSql(schema);
     },
-    showSchemasQuery: function(){   
+    showSchemasQuery: function(){
       return 'SELECT name FROM sys.Tables;';
     },
     /*
@@ -93,6 +93,10 @@ module.exports = (function() {
     },
 
     addColumnQuery: function(tableName, key, dataType) {
+      // FIXME: attributeToSQL SHOULD be using attributes in addColumnSql
+      //        but instead we need to pass the key along as the field here
+      dataType.field = key;
+
       var query = [
         SqlGenerator.alterTableSql(tableName),
         SqlGenerator.addColumnSql(key, dataType)
@@ -161,13 +165,13 @@ module.exports = (function() {
 
       for(var key in attributes){
         var aliasKey = attributes[key].field || key;
-        if(ignoreKeys.indexOf(aliasKey) < 0){ 
+        if(ignoreKeys.indexOf(aliasKey) < 0){
           ignoreKeys.push(aliasKey);
         }
         if(attributes[key].autoIncrement){
           for(var i = 0; i < attrValueHashes.length; i++){
             if(aliasKey in attrValueHashes[i]){
-              delete attrValueHashes[i][aliasKey];            
+              delete attrValueHashes[i][aliasKey];
             }
           }
         }
@@ -203,7 +207,7 @@ module.exports = (function() {
           query += SqlGenerator.insertSql(tableName);
         }
       }
-      return query; 
+      return query;
     },
     /*
       Returns an update query.
@@ -229,7 +233,7 @@ module.exports = (function() {
             delete attrValueHash[aliasKey];
           }
           if(attrValueHash[aliasKey] && attrValueHash[aliasKey].fn){
-            
+
           }
         }
         if(!Object.keys(attrValueHash).length){
@@ -444,7 +448,7 @@ module.exports = (function() {
         }
 
         // add 1st string as quoted, 2nd as unquoted raw
-        var sql = (i > 0 ? SqlGenerator.quoteIdentifier(tableNames.join('.')) + '.' : '') 
+        var sql = (i > 0 ? SqlGenerator.quoteIdentifier(tableNames.join('.')) + '.' : '')
           + this.quote(obj[i], parent, force);
         if (i < len - 1) {
           sql += ' ' + obj[i + 1];


### PR DESCRIPTION
There a whole bunch wrong here, but mostly with sequelize. First and
foremost attributeToSQL (the convention) should be working with attributes,
however it's using dataTypes here because.. well every other dialect does
this too. addColumnQuery as defined in the abstract QueryGenerator class
says you should be using attributes, but everyone else uses (key, dataType).
This is a kludge to make ENUMs work for TSQL, since it needs to know the
field name to generate the SQL
