### PR TITLE
remove faulty logic in update code

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -226,29 +226,27 @@ module.exports = (function() {
       var query;
       attrValueHash = Utils.removeNullValuesFromHash(attrValueHash, false, options);
 
-      //very unique case for cascades, i generally don't approve
-      if(Object.keys(attrValueHash).length === 1 && attributes[Object.keys(attrValueHash)[0]].primaryKey){
-        this.sequelize.log('Updating a Primary Key is not supported in MSSQL, please restructure your query');
-      }else{
-        for(var key in attributes){
-          var aliasKey = attributes[key].field || key;
-          if(attributes[key].primaryKey && attrValueHash[aliasKey]){
-            delete attrValueHash[aliasKey];
-          }
-          if(attrValueHash[aliasKey] && attrValueHash[aliasKey].fn){
+      for (var key in attributes) {
+        var aliasKey = attributes[key].field || key;
+        if (attributes[key].primaryKey && attrValueHash[aliasKey]) {
+          delete attrValueHash[aliasKey];
+        }
 
-          }
+        if (attrValueHash[aliasKey] && attrValueHash[aliasKey].fn) {
+
         }
-        if(!Object.keys(attrValueHash).length){
-          return '';
-          //return ['SELECT * FROM ', tableName, 'WHERE', this.getWhereConditions(where) + ';'].join(' ');
-        }
-        query = [
-          SqlGenerator.updateSql(tableName, attrValueHash, attributes),
-          'WHERE',
-          this.getWhereConditions(where)
-        ].join(' ') + ';';
       }
+
+      if (!Object.keys(attrValueHash).length) {
+        return '';
+        //return ['SELECT * FROM ', tableName, 'WHERE', this.getWhereConditions(where) + ';'].join(' ');
+      }
+
+      query = [
+        SqlGenerator.updateSql(tableName, attrValueHash, attributes),
+        'WHERE',
+        this.getWhereConditions(where)
+      ].join(' ') + ';';
 
       return query;
     },

--- a/test/dao-factory.test.js
+++ b/test/dao-factory.test.js
@@ -722,13 +722,13 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
                     where: {username: 'foo'},
                     defaults: { foo: 'asd' },
                     transaction: t
-                  }).spread(function(user3) {                    
-                    if(dialect !== 'mssql'){             
-                      expect(user1.isNewRecord).to.be.true       
-                    }  
+                  }).spread(function(user3) {
+                    if(dialect !== 'mssql'){
+                      expect(user1.isNewRecord).to.be.true
+                    }
                     expect(user2.isNewRecord).to.be.false
                     expect(user3.isNewRecord).to.be.false
-                    t.commit().success(function() { 
+                    t.commit().success(function() {
                       done()
                     })
                   })
@@ -1630,7 +1630,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
                     expect(min1).to.be.not.ok
                   }
                   expect(min2).to.equal(5)
-                  
+
                   t.rollback().success(function(){ done() })
                 })
               })
@@ -1936,7 +1936,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
             } else if (dialect === 'mssql'){
               expect(self.UserSpecialSync.getTableName().toString()).to.equal('special.UserSpecials');
               expect(UserSpecial.indexOf('INSERT INTO "special.UserSpecials"')).to.be.above(-1)
-              expect(UserPublic.indexOf('INSERT INTO "UserPublics"')).to.be.above(-1)      
+              expect(UserPublic.indexOf('INSERT INTO "UserPublics"')).to.be.above(-1)
             } else {
               expect(self.UserSpecialSync.getTableName().toString()).to.equal('`special.UserSpecials`');
               expect(UserSpecial.indexOf('INSERT INTO `special.UserSpecials`')).to.be.above(-1)
@@ -2112,7 +2112,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
       })
     })
   })
-  
+
   //mssql is not supported by the sql package
   if(dialect !== 'mssql'){
     describe("syntax sugar", function() {


### PR DESCRIPTION
I imagine this change was a first stab at handling MSSQLs very strict rules on circular cascades, however the logic is now incorrect (especially since cascades are completely cleared out when detected to be false). 
