### PR TITLE
should fix sequelize/sequelize#3284

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -168,15 +168,20 @@ module.exports = (function() {
       options = options || {};
 
       var query
-        , valueQuery = 'INSERT<%= ignore %> INTO <%= table %> (<%= attributes %>)<%= output %> VALUES (<%= values %>)'
-        , emptyQuery = 'INSERT<%= ignore %> INTO <%= table %><%= output %>'
+        , valueQuery = '<%= tmpTableForMSSQL %>INSERT<%= ignore %> INTO <%= table %> (<%= attributes %>)<%= output %> VALUES (<%= values %>) <%= selectFromTmp %>'
+        , emptyQuery = '<%= tmpTableForMSSQL %>INSERT<%= ignore %> INTO <%= table %><%= output %> <%= selectFromTmp %>'
         , outputFragment
         , fields = []
         , values = []
         , key
         , value
         , identityWrapperRequired = false
-        , modelAttributeMap = {};
+        , modelAttributeMap = {}
+        , tmpTableForMSSQL = ''
+        , selectFromTmp = ''
+        , tmpColumns = ''
+        , outputColumns = ''
+        , attribute;
 
       if (modelAttributes) {
         Utils._.each(modelAttributes, function(attribute, key) {
@@ -198,7 +203,39 @@ module.exports = (function() {
           valueQuery += ' RETURNING *';
           emptyQuery += ' RETURNING *';
         } else if (!!this._dialect.supports.returnValues.output) {
-          outputFragment = ' OUTPUT INSERTED.*';
+          //Loop through each field type for this table and create a variable table for the output of INSERTED table
+          if (modelAttributes) {
+            tmpTableForMSSQL = 'declare @tmp table (<%= columns %>); '
+
+            for (key in modelAttributes){
+              attribute = modelAttributes[key];
+              if (attribute.type.toString().toUpperCase() != 'VIRTUAL'){
+                if (tmpColumns.length > 0){
+                  tmpColumns += ','
+                  outputColumns += ','
+                }
+
+                //This is a hack, we should determine the size of the field and use that.
+                //However, having a max doesn't hurt,
+                if(attribute.type.toString().toUpperCase().indexOf('NVARCHAR') > -1)
+                {
+                  tmpColumns += attribute.fieldName + ' NVARCHAR(MAX)'
+                }
+                else{
+                  tmpColumns += attribute.fieldName + ' ' + attribute.type.toString()
+                }
+                outputColumns += 'INSERTED.' + attribute.fieldName
+              }
+            }
+
+            var replacement ={
+              columns : tmpColumns
+            }
+
+            tmpTableForMSSQL = Utils._.template(tmpTableForMSSQL)(replacement).trim();
+            outputFragment = ' OUTPUT ' + outputColumns + ' into @tmp';
+            selectFromTmp = ';select * from @tmp';
+          }
         }
       }
 
@@ -253,7 +290,9 @@ module.exports = (function() {
         table: this.quoteTable(table),
         attributes: fields.join(','),
         output: outputFragment,
-        values: values.join(',')
+        values: values.join(','),
+        tmpTableForMSSQL: tmpTableForMSSQL,
+        selectFromTmp: selectFromTmp
       };
 
       query = (replacements.attributes.length ? valueQuery : emptyQuery) + ';';
@@ -295,9 +334,14 @@ module.exports = (function() {
       var query
         , values = []
         , outputFragment
-        , modelAttributeMap = {};
+        , modelAttributeMap = {}
+        , tmpTableForMSSQL = ''
+        , selectFromTmp = ''
+        , tmpColumns = ''
+        , outputColumns = ''
+        , attribute;
 
-      query = 'UPDATE <%= table %> SET <%= values %><%= output %> <%= where %>';
+      query = '<%= tmpTableForMSSQL %>UPDATE <%= table %> SET <%= values %><%= output %> <%= where %> <%= selectFromTmp %>';
 
       if (this._dialect.supports['LIMIT ON UPDATE'] && options.limit) {
         query += ' LIMIT ' + this.escape(options.limit) + ' ';
@@ -306,7 +350,40 @@ module.exports = (function() {
       if (this._dialect.supports.returnValues) {
         if (!!this._dialect.supports.returnValues.output) {
           // we always need this for mssql
-          outputFragment = ' OUTPUT INSERTED.*';
+
+          //Loop through each field type for this table and create a variable table for the output of INSERTED table
+          if (attributes) {
+            tmpTableForMSSQL = 'declare @tmp table (<%= columns %>); '
+
+            for (key in attributes){
+              attribute = attributes[key];
+              if (attribute.type.toString().toUpperCase() != 'VIRTUAL'){
+                if (tmpColumns.length > 0){
+                  tmpColumns += ','
+                  outputColumns += ','
+                }
+
+                //This is a hack, we should determine the size of the field and use that.
+                //However, having a max doesn't hurt,
+                if(attribute.type.toString().toUpperCase().indexOf('NVARCHAR') > -1)
+                {
+                  tmpColumns += attribute.fieldName + ' NVARCHAR(MAX)'
+                }
+                else{
+                  tmpColumns += attribute.fieldName + ' ' + attribute.type.toString()
+                }
+                outputColumns += 'INSERTED.' + attribute.fieldName
+              }
+            }
+
+            var replacement ={
+              columns : tmpColumns
+            }
+
+            tmpTableForMSSQL = Utils._.template(tmpTableForMSSQL)(replacement).trim();
+            outputFragment = ' OUTPUT ' + outputColumns + ' into @tmp';
+            selectFromTmp = ';select * from @tmp';
+          }
         } else if (this._dialect.supports.returnValues && options.returning) {
           query += ' RETURNING *';
         }
@@ -337,7 +414,10 @@ module.exports = (function() {
         table: this.quoteTable(tableName),
         values: values.join(','),
         output: outputFragment,
-        where: this.whereQuery(where)
+        where: this.whereQuery(where),
+        tmpTableForMSSQL: tmpTableForMSSQL,
+        selectFromTmp: selectFromTmp
+
       };
 
       if (values.length === 0) {
@@ -2114,4 +2194,3 @@ module.exports = (function() {
 
   return QueryGenerator;
 })();
-


### PR DESCRIPTION
adjusts the query for insert and update for mssql when triggers are
being used.  It adds a temp table, which will hold the inserted/updated
row and then select it from there.  Before this, it was retrieving the
changed row by select Inserted.\* which didn’t work if triggers were on
the table.
